### PR TITLE
Add open specs for Waco Porch Deck Plan 12x16

### DIFF
--- a/categories/decks/Waco Porch Deck Plan – 12x16/open-specs.json
+++ b/categories/decks/Waco Porch Deck Plan – 12x16/open-specs.json
@@ -1,0 +1,28 @@
+{
+  "plan_id": "DECK-12x16_WACO-2025",
+  "name": "Waco Porch Deck Plan – 12x16",
+  "category": "decks",
+  "dimensions_ft": "12x16",
+  "type": ["porch", "attached", "stairs", "railing", "pergola"],
+  "material_type": ["pressure-treated timber", "composite decking"],
+  "skill_level": "Advanced",
+  "snow_load_psf": null,
+  "wind_rating_mph": 130,
+  "climate_zone": [],
+  "open_features": [
+    "Concrete footings 18×18×12 in (typ.) for 6×6 posts",
+    "6×6 posts (SP No.2) with Simpson ABU66Z post bases",
+    "Beams: (2) 2×12 SP No.2 (Beam 1); (2) 2×12 SP No.2 (Beam 2); (1) 2×12 SP No.2 (Beam 3)",
+    "Ledger: (1) 2×12 SP No.2",
+    "Joists: 2×6 SP No.2 @ 12 in O.C. with Simpson H1A ties",
+    "Stairs: 2×12 stringers @ 12 in O.C.; stair footing 36×24×4 in; Simpson A34/LSC connections",
+    "Railing: 4×4 posts @ 4 ft O.C.; 2×4 top/bottom rails; 2×2 pickets @ ~5–6 in O.C. (≤4 in gap)",
+    "Decking: 2×6 composite; 1/8 in typical gap after drying",
+    "Lean‑to pergola: 2×8 beams (double), 2×8 rafters @ 16 in O.C., 4×2 battens @ 16 in O.C.; Simpson LPC4Z beam‑to‑post with thru‑bolts"
+  ],
+  "estimated_build_cost_usd": null,
+  "product_url": "https://bamboodesigns.shop/products/waco-porch-deck-plan-12x16",
+  "image_url": "https://i.etsystatic.com/59867749/r/il/placeholder/0000000000/il_fullxfull.0000000000_example.jpg",
+  "license": "CC BY 4.0",
+  "version_introduced": "v1.0"
+}


### PR DESCRIPTION
## Summary
- Add open spec entry for the Waco Porch Deck Plan – 12x16.
- Set skill level to Advanced and list detailed structural features.

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest` *(no tests found)*
- `pip install jsonschema` *(fails: ProxyError: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68a9fa83c304832dbe1c285d51a0f297