### PR TITLE
Add open specs for Waco Porch Deck Plan – 12x16

### DIFF
--- a/categories/decks/Waco Porch Deck Plan – 12x16/open-specs.md
+++ b/categories/decks/Waco Porch Deck Plan – 12x16/open-specs.md
@@ -1,0 +1,23 @@
+# Waco Porch Deck Plan – 12x16 Freestanding Deck with Lean-To Pergola (12x16)
+**SKU:** DECK-12x16_FS-2025
+**Category:** decks · **Type:** porch, freestanding, pergola, stairs, railing
+**Materials:** pressure-treated timber, composite decking
+**Skill:** Advanced · **Wind:** 130 mph · **Snow:** —
+**Climate:** —
+**Est. Build Cost:** —
+
+![Deck Image](https://bamboodesigns.shop/cdn/shop/files/waco-porch-deck-plan-12x16.jpg)
+
+## Open Features
+- 18×18×12 in square concrete footings (typ.)
+- 6×6 posts (SP No.2) with Simpson ABU66Z post base
+- Beams: (2) 2×12 SP No.2 (Beam 1); (2) 2×12 SP No.2 (Beam 2); (1) 2×12 SP No.2 (Beam 3)
+- Ledger: (1) 2×12 SP No.2
+- Joists: 2×6 SP No.2 @ 12 in O.C. with Simpson H1A ties
+- 2×12 stair stringers @ 12 in O.C.; Simpson A34/LSC connections
+- Railing: 4×4 posts @ 4 ft O.C.; 2×4 top/bottom rails; 2×2 pickets @ ~5 in O.C. (≤4 in gap)
+- Decking: 2×6 composite decking; 1/8 in gap typical after drying
+- Lean-To pergola: 6×6 posts with 2×8 beams and 2×6 rafters @ 24 in O.C.
+
+**Product:** [Waco Porch Deck Plan – 12x16 Freestanding Deck with Lean-To Pergola](https://bamboodesigns.shop/products/waco-porch-deck-plan-12x16-freestanding-deck-with-lean-to-pergola)
+**License:** CC BY 4.0 · **Introduced:** v1.0


### PR DESCRIPTION
## Summary
- add open-specs document for Waco Porch Deck Plan – 12x16 with lean-to pergola
- list nine open features and upgrade skill rating to Advanced with 130 mph wind
- ensure product link is single-line without extraneous markers

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a9fa84e048832da4a67dc435b274d9